### PR TITLE
Typo and instructions update

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Here's a streamlined guide to get you started with a clean development environme
    3. Install Project Dependencies (Inside the Container):
       - Once connected to the development container, you'll need to install the project's dependencies listed in the requirements.txt file. Open the integrated terminal within the container and run the following command:
       ```
+      sudo apt-get update && sudo apt-get install pip
       pip install -r requirements.txt
       ```
    4. Congratulations! 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Hello Worldannotated-types==0.6.0
+annotated-types==0.6.0
 anyio==4.2.0
 bcrypt==4.1.2
 certifi==2024.2.2


### PR DESCRIPTION
 Removed typo in requirements.txt
 - typo created error when installing requirements by file
 
 Updated setup instructions to include command to install pip 
 - Followed instructions to set up dev container, but pip was missing.